### PR TITLE
Fixed broken link.

### DIFF
--- a/docs/do-science/faq/README.md
+++ b/docs/do-science/faq/README.md
@@ -9,7 +9,7 @@ description: Frequently asked questions
 
 This FAQ is intended for lab users that do science in labs:
 
-- [Users](/do-science/faq/users)
+- [Access](/do-science/faq/access/)
 - [Storage](/do-science/faq/storage)
 - [Compute](/do-science/faq/compute)
 - [Internal transfers](/do-science/faq/internal-transfer)

--- a/docs/do-science/faq/compute.md
+++ b/docs/do-science/faq/compute.md
@@ -201,7 +201,7 @@ sudo reboot
 ```
 
 ::: warning
-Please be aware that restarts will affect all of your lab colleagues working on your machine. Our advice is to carefully plan restarts with your lab colleagues and announce such restarts in advance so no one looses their valuable work. [Click here](/do-science/faq/users/#how-can-i-see-users-currently-logged-into-a-machine) to see which users that are currently logged into your machines.
+Please be aware that restarts will affect all of your lab colleagues working on your machine. Our advice is to carefully plan restarts with your lab colleagues and announce such restarts in advance so no one looses their valuable work. [Click here](/do-science/faq/access/#how-can-i-see-users-currently-logged-into-a-machine) to see which users that are currently logged into your machines.
 :::
 
 ### What privileges does my account have?


### PR DESCRIPTION
The `/faq/users/` no longer exists and the section in question has been moved to `/faq/access`